### PR TITLE
Switch to gettext

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+ENV = env
+BIN = $(ENV)/bin
+PIP = $(BIN)/pip
+PYTHON = $(BIN)/python
+PYTEST = $(BIN)/pytest
+
+
+environ: $(ENV)/.done
+
+.PHONY: help
+help:
+	@echo "make                         # build everything"
+	@echo "make run                     # run dev server"
+	@echo "make test                    # run unit tests"
+
+$(PIP):
+	python -m venv env
+	$(PIP) install -U pip setuptools wheel
+
+$(ENV)/.done: $(PIP) requirements.txt
+	$(PIP) install -r requirements.txt -e .
+	touch env/.done
+
+.PHONY: run
+run: environ
+	$(PYTHON) manage.py runserver
+
+.PHONY: test
+test: environ
+	$(PYTEST) -vv --tb=native weekday_field/tests
+
+.PHONY: clean
+clean: clean_pycache
+	rm -rf $(ENV) weekday_field.egg-info
+
+.PHONY: clean_pycache
+.clean_pycache:
+	find . -name "__pycache__" -type d -exec rm -rf "{}" +
+	find . -name "*.pyc" -delete

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,13 @@
+# Weekday field
+
+## Build
+
+```
+make
+```
+
+## Test
+
+```
+make test
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django==2.1.9
-pytest==4.0.0
-pytest-django==3.4.4
+Django==3.1.4
+pytest==6.1.2
+pytest-django==4.1.0

--- a/weekday_field/utils.py
+++ b/weekday_field/utils.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 DAY_CHOICES = (
     (0, _("Monday")),


### PR DESCRIPTION
Django will deprecate use of `ugettext_lazy` [0]

Also add automated builds and upgrade dependencies.

[0] https://docs.djangoproject.com/en/3.1/releases/3.0/#id3